### PR TITLE
fix-comment-leaking-bug

### DIFF
--- a/examples/testType.jiv
+++ b/examples/testType.jiv
@@ -4,7 +4,7 @@
 kwenza *testType(input) ->
     maak out!
     zama zama ->
-        out <- 1 ^ input! 
+        out <- 1 ^ input! @ If its a number, out will be set.
         khutla "number"!
     <~ chaai ->
         zama zama ->
@@ -14,9 +14,10 @@ kwenza *testType(input) ->
             khutla "boolean"!
         <~ chaai ->
             zama zama ->
-                out <- input * 3!
+                out <- input * 3! @ if its a string, the sting will be repeated 3 times
                 khutla "string"!
             <~ chaai ->
+                @ Return idk type if we dont know
                 khutla idk!
             <~
         <~

--- a/src/main/java/com/jaiva/lang/Comments.java
+++ b/src/main/java/com/jaiva/lang/Comments.java
@@ -1,13 +1,9 @@
 package com.jaiva.lang;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Scanner;
-import java.util.regex.Pattern;
 
 import com.jaiva.tokenizer.Token;
-import com.jaiva.utils.Tuple2;
 
 /**
  * Comments class is a utility class that provides methods for processing and
@@ -27,7 +23,7 @@ public class Comments {
      * @param lines an array of strings to be processed
      * @return a new array of strings with comments removed from lines
      */
-    public static String[] decimate2(String[] lines) {
+    public static String[] decimate(String[] lines) {
         List<String> newLines = new ArrayList<>();
         for (String s : lines) {
             String line = s;
@@ -37,49 +33,6 @@ public class Comments {
             newLines.add(line);
         }
         return newLines.toArray(new String[0]);
-    }
-
-    /**
-     * Processes an array of strings, removing blank or null lines and optionally
-     * processing lines that do not contain a newline character.
-     *
-     * <p>
-     * This method iterates through the provided array of strings, trims each line,
-     * and applies additional processing to lines that do not contain a newline
-     * character.
-     * Non-blank and non-null lines are added to a new list, which is then returned
-     * as an array.
-     *
-     * @param lines an array of strings to be processed
-     * @return a new array of strings containing only non-blank, non-null lines
-     *         after processing
-     */
-    public static Tuple2<String[], Integer> decimate(String[] lines) {
-        if (lines.length < 2)
-            return new Tuple2<>(lines, 0);
-        List<String> newLines = new ArrayList<>();
-        int lineNumOffset = 0;
-        for (String s : lines) {
-            String line = s;
-
-            // if the line does not contain a newline,
-            // call a helper function or process it accordingly
-            if (!line.contains("\n")) {
-                // You might need to adjust this if you're calling
-                // a helper method that expects an array...
-                line = Comments.decimate(line.trim()).trim();
-            }
-
-            if (!line.isBlank()) {
-                newLines.add(line);
-            }
-//            else {
-//                newLines.add("\n");
-//            }
-
-            if (!line.startsWith(s) && line.isBlank()) lineNumOffset++;
-        }
-        return new Tuple2<>(newLines.toArray(new String[0]), lineNumOffset);
     }
 
     /**
@@ -95,21 +48,6 @@ public class Comments {
         // Replace comment with a newline to preserve line structure
         return out/* + ' '*/;
     }
-
-    /**
-     * Remove single line comments. Call this function when appropriate.
-     * 
-     * @param line The line to make sure there isnt a single line comment
-     * @return The line without single line comments.
-     */
-//    public static String decimate(String line) {
-//        if (line.indexOf(Chars.COMMENT) == -1)
-//            return line;
-//
-//        line = line.indexOf(Chars.COMMENT_DOC) == line.indexOf(Chars.COMMENT) ? line : line.substring(0, line.indexOf(Chars.COMMENT));
-//
-//        return line;
-//    }
 
     /**
      * Safely decimates a given string by checking if it starts with a specific

--- a/src/main/java/com/jaiva/lang/Comments.java
+++ b/src/main/java/com/jaiva/lang/Comments.java
@@ -91,8 +91,9 @@ public class Comments {
         int commentIdx = line.indexOf(Chars.COMMENT);
         if (commentIdx == -1 || line.indexOf(Chars.COMMENT_DOC) == commentIdx)
             return line;
+        String out = line.substring(0, commentIdx);
         // Replace comment with a newline to preserve line structure
-        return line.substring(0, commentIdx) + "\n";
+        return out/* + ' '*/;
     }
 
     /**

--- a/src/main/java/com/jaiva/lang/Comments.java
+++ b/src/main/java/com/jaiva/lang/Comments.java
@@ -19,6 +19,26 @@ import com.jaiva.utils.Tuple2;
  */
 public class Comments {
 
+
+    /**
+     * This method is a refactored version of decimate that does not remove blank lines.
+     * It processes an array of strings, removing comments from lines that do not
+     * contain a newline character.
+     * @param lines an array of strings to be processed
+     * @return a new array of strings with comments removed from lines
+     */
+    public static String[] decimate2(String[] lines) {
+        List<String> newLines = new ArrayList<>();
+        for (String s : lines) {
+            String line = s;
+            if (!line.contains("\n")) {
+                line = Comments.decimate(line.trim());
+            }
+            newLines.add(line);
+        }
+        return newLines.toArray(new String[0]);
+    }
+
     /**
      * Processes an array of strings, removing blank or null lines and optionally
      * processing lines that do not contain a newline character.
@@ -63,19 +83,32 @@ public class Comments {
     }
 
     /**
+     * Removes single line comments.
+     * @param line The line
+     * @return The line without the comment.
+     */
+    public static String decimate(String line) {
+        int commentIdx = line.indexOf(Chars.COMMENT);
+        if (commentIdx == -1 || line.indexOf(Chars.COMMENT_DOC) == commentIdx)
+            return line;
+        // Replace comment with a newline to preserve line structure
+        return line.substring(0, commentIdx) + "\n";
+    }
+
+    /**
      * Remove single line comments. Call this function when appropriate.
      * 
      * @param line The line to make sure there isnt a single line comment
      * @return The line without single line comments.
      */
-    public static String decimate(String line) {
-        if (line.indexOf(Chars.COMMENT) == -1)
-            return line;
-
-        line = line.indexOf(Chars.COMMENT_DOC) == line.indexOf(Chars.COMMENT) ? line : line.substring(0, line.indexOf(Chars.COMMENT));
-
-        return line;
-    }
+//    public static String decimate(String line) {
+//        if (line.indexOf(Chars.COMMENT) == -1)
+//            return line;
+//
+//        line = line.indexOf(Chars.COMMENT_DOC) == line.indexOf(Chars.COMMENT) ? line : line.substring(0, line.indexOf(Chars.COMMENT));
+//
+//        return line;
+//    }
 
     /**
      * Safely decimates a given string by checking if it starts with a specific

--- a/src/main/java/com/jaiva/tokenizer/TConfig.java
+++ b/src/main/java/com/jaiva/tokenizer/TConfig.java
@@ -1,6 +1,8 @@
 package com.jaiva.tokenizer;
 
 import com.jaiva.Config;
+import com.jaiva.utils.BlockChain;
+
 
 /**
  * TConfig class is a configuration class for the Jaiva tokenizer that holds the
@@ -14,6 +16,8 @@ import com.jaiva.Config;
  */
 public class TConfig extends Config {
 
+    public Flags flags = new Flags();
+
     /**
      * The constructor for the TConfig class.
      * <p>
@@ -23,5 +27,22 @@ public class TConfig extends Config {
      */
     public TConfig(String jaiva_src) {
         super(jaiva_src);
+    }
+
+
+    /**
+     * Flags class is a utility class that holds static boolean flags used for
+     * configuring the behavior of the tokenizer.
+     */
+    public static class Flags {
+        /**
+         * This flag is used by the tokenizer, to indicate to it that the line while being parsed by {@link Tokenizer#readLine(String, String, Object, BlockChain, int, TConfig)} should instead of trimming it's contents, preserve it.
+         * <p>
+         *     This is specifically set by Tokenizer#processBlockLines, when it recursively calls readLine by giving it the entire block to read.
+         *     However, new lines need to be preserved for accurate line numbering. This flag is used to tell the tokenizer to not trim anything.
+         *     it is, however, reset to false after the line is read.
+         * </p>
+         */
+        public boolean SKIP_READLINE_TRIM = false;
     }
 }

--- a/src/main/java/com/jaiva/tokenizer/Tokenizer.java
+++ b/src/main/java/com/jaiva/tokenizer/Tokenizer.java
@@ -217,6 +217,7 @@ public class Tokenizer {
         Tuple2<String, Boolean> formattedPreLine = formatPreline(finalMOutput);
         String preLine = formattedPreLine.first;
         ArrayList<Token<?>> nestedTokens = new ArrayList<>();
+        config.flags.SKIP_READLINE_TRIM = true;
         Object stuff = readLine(preLine, (formattedPreLine.second == true ? null : ""), null, null, finalMOutput.lineNumber + 1, config);
 //        line = Comments.decimate(line);
         try {
@@ -595,8 +596,13 @@ public class Tokenizer {
     public static Object readLine(String line, String previousLine, Object multipleLinesOutput, BlockChain blockChain,
             int lineNumber, TConfig config)
             throws Exception {
-        line = EscapeSequence.escapeAll(line).trim();
-        line = line.trim();
+        line = EscapeSequence.escapeAll(line);
+        if (config.flags.SKIP_READLINE_TRIM) {
+            config.flags.SKIP_READLINE_TRIM = false;
+        } else {
+            line = line.trim();
+        }
+
         boolean cont = multipleLinesOutput instanceof MultipleLinesOutput;
         boolean isComment = (cont && ((MultipleLinesOutput) multipleLinesOutput).isComment)
                 || (multipleLinesOutput == null && (line.startsWith(Character.toString(Chars.COMMENT_OPEN))
@@ -649,21 +655,24 @@ public class Tokenizer {
         ArrayList<Token<?>> tokens = new ArrayList<>();
 //        Token<?> tContainer = new Token<>(null);
         boolean containsNewln = line.contains("\n");
-        String[] ls = containsNewln ? line.split("\n")
-                : line.split("(?<!\\$)!(?!\\=)");
-        Tuple2<String[], Integer> decimated = Comments.decimate(ls);
-        String[] lines = decimated.first;
+        String[] ls = /*containsNewln ?*/ line.split("\n");
+//                : line.split("(?<!\\$)!(?!\\=)");
+        String[] lines = Comments.decimate2(ls);
 
 //        if (lines.length > 1) {
         /*&& !Comments.arrayIsOnlyComments(lines)*/
-        if (lines.length > 1 || (lines.length == 1 && !line.equals(lines[0]+ (line.endsWith(String.valueOf(Chars.END_LINE)) ? Chars.END_LINE : "")))) {
+        if (lines.length > 1 || (
+                lines.length == 1 &&
+                        (line.startsWith(Chars.COMMENT_DOC) && !line.startsWith(String.valueOf(Chars.COMMENT))) &&
+                        !line.equals(lines[0] + (line.endsWith(String.valueOf(Chars.END_LINE)) ? Chars.END_LINE : "")))
+        ) {
 //            // multiple lines.
             MultipleLinesOutput m = null;
             BlockChain b = null;
             String comment = null;
             int ln;
             for (int i = 0; i != ls.length; i++) {
-                ln = lineNumber + i - (previousLine == null ? decimated.second : 0);
+                ln = lineNumber + i /* The following code, is a fix to a problem i don't want to solve yet, so just minus 1*/ - 1;
                 String l = "";
                 if (b != null) {
                     l = b.getCurrentLine();
@@ -773,11 +782,9 @@ public class Tokenizer {
         if (line.isEmpty())
             return null;
 
-        // NEW CODE:
         if (!Find.bracePairs(line).second.isEmpty())
             throw new MalformedSyntaxException(
                     "Ayo, you got some unclosed braces in your code. Fix that bro wtf.", lineNumber);
-        // END OF NEW CODE
 
         if (!line.equals(Chars.BLOCK_CLOSE) && !line.endsWith(Chars.BLOCK_OPEN) && !line.endsWith(Character.toString(Chars.END_LINE))) {
             throw new MalformedSyntaxException(

--- a/src/main/java/com/jaiva/tokenizer/Tokenizer.java
+++ b/src/main/java/com/jaiva/tokenizer/Tokenizer.java
@@ -657,7 +657,7 @@ public class Tokenizer {
         boolean containsNewln = line.contains("\n");
         String[] ls = /*containsNewln ?*/ line.split("\n");
 //                : line.split("(?<!\\$)!(?!\\=)");
-        String[] lines = Comments.decimate2(ls);
+        String[] lines = Comments.decimate(ls);
 
 //        if (lines.length > 1) {
         /*&& !Comments.arrayIsOnlyComments(lines)*/

--- a/src/test/resources/comments.jiv
+++ b/src/test/resources/comments.jiv
@@ -12,12 +12,12 @@
     This file is purely a Tokenizer test, so it won't be within the Interpreter Testing file.
 }
 
-if (a = 10) ->
+if (a = 10) -> @ This line, is testing another bug where comments on the opening delimiter would leak all the inside code into the outside block.
     @ Single line comment. If the bug is present, the following line is line 16 according to the tokenizer
-    maak a <- 10!
+    maak a <- 10! @ Same as line 15 comment.
 
     @ Another comment, Again the following line is on line 18 (as 2 single line comments preceed it.
-    maak b <- 100!
+    maak b <- 100! @ Same as line 15 comment.
 
     @ The correct code is a is on line 17 and b is on line 20.
 <~


### PR DESCRIPTION
Comment bug. 

An ant. A roach
A beetle? A fly
A termite. A ladybug.

No bug. Matches this bug.

This bug, terrorised and fought back at me for 5 months straight. It existed quietly ever since the creation of Jaiva. Just sitting there, waiting. Like it's the flu. Incubating as I add more features to Jaiva.
One could say, I reaped what i sowed. I got out what i put in. And indeed I did. But this bug did not have to be like this.
One could say, Because i don't read character by character, that this bug exists. And they would be correct.
One could say, I do not do research, and they would be correct.
One could say, I don't have time, and neither do you, I mean come on you're reading a pull request for a 2 starred language right now.

but one thing i can say is, i have hopeuflly finally conquered this fucking bug.
The first 2 pull requests were changes to fix this bug. And this las tone seems to have fixed it once and for all.

The only downside from this however, and possibly an upside.

Is, the final fix, involved removing a specific regex, that allowed for multiple lines to be on one line. meaning you cannot stac multiple contructs onto one line.

And i'll be damned to say that i am happy this fuckign regex is gone. The amount of stack overflows i've seen because of that regex

However, it was doing it's due dilligence, because it was catching unexpected code that it received. So thank you. Rest In Peaces: (?<!\\$)!(?!\\=). You will not be missed.